### PR TITLE
re-add CurseDep plugin

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -9,6 +9,7 @@ repositories {
     mavenCentral()
     maven { url = 'https://maven.minecraftforge.net' }
     maven { url = 'https://maven.parchmentmc.org' }
+    maven { url = 'https://noeppi-noeppi.github.io/MinecraftUtilities/maven' }
 }
 
 dependencies {
@@ -24,6 +25,7 @@ dependencies {
     implementation ('commons-io:commons-io') { version { strictly '[2.11.0,)';  prefer '2.11.0' } }
     implementation ('org.apache.maven:maven-artifact') { version { strictly '[3.8.1,)';  prefer '3.8.1' } }
     implementation ('commons-io:commons-io') { version { strictly '[2.10.0,)';  prefer '2.10.0' } }
+    implementation('io.github.noeppi_noeppi.tools:CurseWrapper') { version { strictly '[0.3, 1.0)'; prefer '0.3' } }
     
     // See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228
     implementation('org.apache.logging.log4j:log4j-api') { version { strictly '[2.16.0,)' } }
@@ -47,6 +49,10 @@ gradlePlugin {
         sourcejar {
             id = 'io.github.noeppi_noeppi.tools.modgradle.sourcejar'
             implementationClass = 'io.github.noeppi_noeppi.tools.modgradle.plugins.sourcejar.SourceJarPlugin'
+        }
+        cursedep {
+            id = 'io.github.noeppi_noeppi.tools.modgradle.cursedep'
+            implementationClass = 'io.github.noeppi_noeppi.tools.modgradle.plugins.cursedep.CurseDepPlugin'
         }
         coremods {
             id = 'io.github.noeppi_noeppi.tools.modgradle.coremods'

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDepPlugin.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDepPlugin.java
@@ -5,6 +5,7 @@ import net.minecraftforge.gradle.userdev.DependencyManagementExtension;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URI;
 
@@ -31,7 +32,11 @@ public class CurseDepPlugin implements Plugin<Project> {
     }
 
     public static String curseArtifact(String slug, int projectId, int fileId) {
-        return "curse.maven:" + slug + "-" + projectId + ":" + fileId;
+        return curseArtifact(slug, projectId, fileId, null);
+    }
+
+    public static String curseArtifact(String slug, int projectId, int fileId, @Nullable String extension) {
+        return "curse.maven:" + slug + "-" + projectId + ":" + fileId + (extension == null ? "" : "@" + extension);
     }
 
     public static String getSlug(int projectId) {

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDepPlugin.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDepPlugin.java
@@ -1,0 +1,44 @@
+package io.github.noeppi_noeppi.tools.modgradle.plugins.cursedep;
+
+import io.github.noeppi_noeppi.tools.cursewrapper.api.CurseWrapper;
+import net.minecraftforge.gradle.userdev.DependencyManagementExtension;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+import java.io.IOException;
+import java.net.URI;
+
+public class CurseDepPlugin implements Plugin<Project> {
+
+    private static final CurseWrapper API = new CurseWrapper(URI.create("https://curse.melanx.de/"));
+
+    @Override
+    public void apply(Project project) {
+        project.getRepositories().maven(r -> {
+            r.setUrl("https://cfa2.cursemaven.com");
+            r.content(c -> c.includeGroup("curse.maven"));
+        });
+        DependencyManagementExtension ext = getDepExt(project);
+        project.getExtensions().create(CurseDependencyExtension.EXTENSION_NAME, CurseDependencyExtension.class, project, ext);
+    }
+
+    private static DependencyManagementExtension getDepExt(Project project) {
+        return project.getExtensions().getByType(DependencyManagementExtension.class);
+    }
+
+    public static String curseArtifact(int projectId, int fileId) {
+        return curseArtifact(getSlug(projectId), projectId, fileId);
+    }
+
+    public static String curseArtifact(String slug, int projectId, int fileId) {
+        return "curse.maven:" + slug + "-" + projectId + ":" + fileId;
+    }
+
+    public static String getSlug(int projectId) {
+        try {
+            return API.getSlug(projectId);
+        } catch (IOException e) {
+            return "unknown";
+        }
+    }
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDependencyExtension.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDependencyExtension.java
@@ -1,0 +1,106 @@
+package io.github.noeppi_noeppi.tools.modgradle.plugins.cursedep;
+
+import com.google.common.collect.Sets;
+import com.google.gson.JsonElement;
+import groovy.lang.GroovyObjectSupport;
+import io.github.noeppi_noeppi.tools.modgradle.ModGradle;
+import net.minecraftforge.gradle.common.util.MavenArtifactDownloader;
+import net.minecraftforge.gradle.userdev.DependencyManagementExtension;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public class CurseDependencyExtension extends GroovyObjectSupport {
+
+    public static final String EXTENSION_NAME = "curse";
+
+    private final Project project;
+
+    @Nullable
+    private final DependencyManagementExtension ext;
+
+    public CurseDependencyExtension(Project project, @Nullable DependencyManagementExtension ext) {
+        this.project = project;
+        this.ext = ext;
+    }
+
+    public Dependency mod(int projectId, int fileId) {
+        return this.createDependency(CurseDepPlugin.curseArtifact(projectId, fileId));
+    }
+
+    public Dependency pack(int projectId, int fileId) {
+        return this.pack(projectId, fileId, Collections.emptyList());
+    }
+
+    public Dependency pack(int projectId, int fileId, List<Object> excludes) {
+        Set<Integer> idExcludes = Sets.newHashSet();
+        Set<String> slugExcludes = Sets.newHashSet();
+
+        for (Object exclude : excludes) {
+            if (exclude instanceof Integer id) {
+                idExcludes.add(id);
+            } else if (exclude instanceof String slug) {
+                slugExcludes.add(slug);
+            } else {
+                throw new IllegalStateException("Cannot add curse ModPack dependency: Excludes must be int (project id) or String (slug). Currently: " + exclude.getClass().getName());
+            }
+        }
+
+        String configName = "cursepack_" + projectId + "_" + fileId + "_" + idExcludes.stream().sorted().map(Object::toString).collect(Collectors.joining("_")) + "_" + slugExcludes.stream().sorted().collect(Collectors.joining("_"));
+        Configuration cache = this.project.getConfigurations().findByName(configName);
+        if (cache != null) {
+            return this.project.getDependencies().create(cache);
+        }
+
+        File file = MavenArtifactDownloader.download(this.project, CurseDepPlugin.curseArtifact("cursepack", projectId, fileId), false);
+        if (file == null) {
+            throw new IllegalStateException("Cannot create curse ModPack dependency: Failed to download manifest");
+        } else try {
+            ZipFile zipFile = new ZipFile(file);
+            ZipEntry entry = zipFile.getEntry("manifest.json");
+            if (entry == null) entry = zipFile.getEntry("/manifest.json");
+            if (entry == null) {
+                throw new IllegalStateException("Cannot create curse ModPack dependency: Pack file contains no manifest");
+            }
+
+            InputStreamReader reader = new InputStreamReader(zipFile.getInputStream(entry));
+            JsonElement json = ModGradle.GSON.fromJson(reader, JsonElement.class);
+            reader.close();
+            Configuration config = this.project.getConfigurations().create(configName);
+
+            for (JsonElement fileJson : json.getAsJsonObject().get("files").getAsJsonArray()) {
+                int p = fileJson.getAsJsonObject().get("projectID").getAsInt();
+                if (!idExcludes.contains(p)) {
+                    int f = fileJson.getAsJsonObject().get("fileID").getAsInt();
+                    String slug = CurseDepPlugin.getSlug(p);
+                    if (!slugExcludes.contains(slug)) {
+                        config.getDependencies().add(this.createDependency(CurseDepPlugin.curseArtifact(slug, p, f)));
+                    }
+                }
+            }
+
+            return this.project.getDependencies().create(config);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot create curse ModPack dependency: " + e.getMessage(), e);
+        }
+    }
+
+    private Dependency createDependency(Object obj) {
+        if (this.ext == null) {
+            return this.project.getDependencies().create(obj);
+        }
+
+        return this.ext.deobf(obj);
+    }
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDependencyExtension.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDependencyExtension.java
@@ -63,7 +63,7 @@ public class CurseDependencyExtension extends GroovyObjectSupport {
             return this.project.getDependencies().create(cache);
         }
 
-        File file = MavenArtifactDownloader.download(this.project, CurseDepPlugin.curseArtifact("cursepack", projectId, fileId), false);
+        File file = MavenArtifactDownloader.download(this.project, CurseDepPlugin.curseArtifact("O", projectId, fileId, "zip"), false);
         if (file == null) {
             throw new IllegalStateException("Cannot create curse ModPack dependency: Failed to download manifest");
         } else try {


### PR DESCRIPTION
This PR re-adds CurseDep plugin with the new API using [CurseWrapper](https://github.com/noeppi-noeppi/CurseWrapper/) and the new [Cursemaven](https://cfa2.cursemaven.com/) endpoint for the new API. The latter one is still a testing version but we should stick to it for now as it's more stable than the stable one which should be unusable soon.

This PR is related to #1