### PR TITLE
Re-add CurseDep and PackDev

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -9,6 +9,7 @@ repositories {
     mavenCentral()
     maven { url = 'https://maven.minecraftforge.net' }
     maven { url = 'https://maven.parchmentmc.org' }
+    maven { url = 'https://noeppi-noeppi.github.io/MinecraftUtilities/maven' }
 }
 
 dependencies {
@@ -24,6 +25,7 @@ dependencies {
     implementation ('commons-io:commons-io') { version { strictly '[2.11.0,)';  prefer '2.11.0' } }
     implementation ('org.apache.maven:maven-artifact') { version { strictly '[3.8.1,)';  prefer '3.8.1' } }
     implementation ('commons-io:commons-io') { version { strictly '[2.10.0,)';  prefer '2.10.0' } }
+    implementation('io.github.noeppi_noeppi.tools:CurseWrapper') { version { strictly '[0.3, 1.0)'; prefer '0.3' } }
     
     // See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228
     implementation('org.apache.logging.log4j:log4j-api') { version { strictly '[2.16.0,)' } }
@@ -47,6 +49,10 @@ gradlePlugin {
         sourcejar {
             id = 'io.github.noeppi_noeppi.tools.modgradle.sourcejar'
             implementationClass = 'io.github.noeppi_noeppi.tools.modgradle.plugins.sourcejar.SourceJarPlugin'
+        }
+        cursedep {
+            id = 'io.github.noeppi_noeppi.tools.modgradle.cursedep'
+            implementationClass = 'io.github.noeppi_noeppi.tools.modgradle.plugins.cursedep.CurseDepPlugin'
         }
         coremods {
             id = 'io.github.noeppi_noeppi.tools.modgradle.coremods'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation('commons-io:commons-io') { version { strictly '[2.11.0,)'; prefer '2.11.0' } }
     implementation('org.apache.maven:maven-artifact') { version { strictly '[3.8.1,)'; prefer '3.8.1' } }
     implementation('commons-io:commons-io') { version { strictly '[2.10.0,)'; prefer '2.10.0' } }
-    implementation('io.github.noeppi_noeppi.tools:CurseWrapper') { version { strictly '[0.3, 1.0)'; prefer '0.3' } }
+    implementation('io.github.noeppi_noeppi.tools:CurseWrapper') { version { strictly '[1.0,)'; prefer '1.0' } }
 
     // See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228
     implementation('org.apache.logging.log4j:log4j-api') { version { strictly '[2.16.0,)' } }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -13,20 +13,20 @@ repositories {
 }
 
 dependencies {
-    implementation ('com.google.code.findbugs:jsr305') { version { strictly '[3.0.1,)';  prefer '3.0.1' } }
-    implementation ('net.minecraftforge:srgutils') { version { strictly '[0.4.3,)';  prefer '0.4.3' } }
-    implementation ('net.minecraftforge.gradle:ForgeGradle') { version { strictly "[5.1.26,5.2)";  prefer '5.1.26' } }
-    implementation ('net.minecraftforge:artifactural') { version { strictly "[3.0.8,)";  prefer '3.0.8' } }
-    compileOnly ('org.parchmentmc:librarian') { version { strictly "[1.1.4,)";  prefer '1.1.4' } }
-    implementation ('de.siegmar:fastcsv') { version { strictly '[2.0.0,)';  prefer '2.0.0' } }
-    implementation ('com.google.code.gson:gson') { version { strictly '[2.8.7,)';  prefer '2.8.7' } }
-    implementation ('com.google.guava:guava') { version { strictly '[30.1.1-jre,)';  prefer '30.1.1-jre' } }
-    implementation ('org.apache.commons:commons-lang3') { version { strictly '[3.12.0,4.0.0)';  prefer '3.12.0' } }
-    implementation ('commons-io:commons-io') { version { strictly '[2.11.0,)';  prefer '2.11.0' } }
-    implementation ('org.apache.maven:maven-artifact') { version { strictly '[3.8.1,)';  prefer '3.8.1' } }
-    implementation ('commons-io:commons-io') { version { strictly '[2.10.0,)';  prefer '2.10.0' } }
+    implementation('com.google.code.findbugs:jsr305') { version { strictly '[3.0.1,)'; prefer '3.0.1' } }
+    implementation('net.minecraftforge:srgutils') { version { strictly '[0.4.3,)'; prefer '0.4.3' } }
+    implementation('net.minecraftforge.gradle:ForgeGradle') { version { strictly "[5.1.26,5.2)"; prefer '5.1.26' } }
+    implementation('net.minecraftforge:artifactural') { version { strictly '[3.0.8,)'; prefer '3.0.8' } }
+    compileOnly('org.parchmentmc:librarian') { version { strictly '[1.1.4,)'; prefer '1.1.4' } }
+    implementation('de.siegmar:fastcsv') { version { strictly '[2.0.0,)'; prefer '2.0.0' } }
+    implementation('com.google.code.gson:gson') { version { strictly '[2.8.7,)'; prefer '2.8.7' } }
+    implementation('com.google.guava:guava') { version { strictly '[30.1.1-jre,)'; prefer '30.1.1-jre' } }
+    implementation('org.apache.commons:commons-lang3') { version { strictly '[3.12.0,4.0.0)'; prefer '3.12.0' } }
+    implementation('commons-io:commons-io') { version { strictly '[2.11.0,)'; prefer '2.11.0' } }
+    implementation('org.apache.maven:maven-artifact') { version { strictly '[3.8.1,)'; prefer '3.8.1' } }
+    implementation('commons-io:commons-io') { version { strictly '[2.10.0,)'; prefer '2.10.0' } }
     implementation('io.github.noeppi_noeppi.tools:CurseWrapper') { version { strictly '[0.3, 1.0)'; prefer '0.3' } }
-    
+
     // See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228
     implementation('org.apache.logging.log4j:log4j-api') { version { strictly '[2.16.0,)' } }
     implementation('org.apache.logging.log4j:log4j-core') { version { strictly '[2.16.0,)' } }
@@ -53,6 +53,10 @@ gradlePlugin {
         cursedep {
             id = 'io.github.noeppi_noeppi.tools.modgradle.cursedep'
             implementationClass = 'io.github.noeppi_noeppi.tools.modgradle.plugins.cursedep.CurseDepPlugin'
+        }
+        packdev {
+            id = 'io.github.noeppi_noeppi.tools.modgradle.packdev'
+            implementationClass = 'io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.PackDevPlugin'
         }
         coremods {
             id = 'io.github.noeppi_noeppi.tools.modgradle.coremods'

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/mappings/MappingMerger.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/mappings/MappingMerger.java
@@ -4,7 +4,10 @@ import net.minecraftforge.srgutils.IMappingBuilder;
 import net.minecraftforge.srgutils.IMappingFile;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class MappingMerger {

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/coremods/BuildCoreModsTask.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/coremods/BuildCoreModsTask.java
@@ -7,7 +7,10 @@ import io.github.noeppi_noeppi.tools.modgradle.util.ProcessUtil;
 import org.apache.commons.io.file.PathUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.file.*;
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.*;
@@ -20,7 +23,8 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public abstract class BuildCoreModsTask extends DefaultTask {
     

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDepPlugin.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDepPlugin.java
@@ -13,7 +13,7 @@ public class CurseDepPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getRepositories().maven(r -> {
-            r.setUrl(CurseUtil.CURSE_MAVEN_URL);
+            r.setUrl(CurseUtil.CURSE_MAVEN);
             r.content(c -> c.includeGroup("curse.maven"));
         });
         DependencyManagementExtension ext = getDepExt(project);

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDepPlugin.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDepPlugin.java
@@ -5,6 +5,7 @@ import net.minecraftforge.gradle.userdev.DependencyManagementExtension;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URI;
 
@@ -31,7 +32,11 @@ public class CurseDepPlugin implements Plugin<Project> {
     }
 
     public static String curseArtifact(String slug, int projectId, int fileId) {
-        return "curse.maven:" + slug + "-" + projectId + ":" + fileId;
+        return curseArtifact(slug, projectId, fileId, null);
+    }
+
+    public static String curseArtifact(String slug, int projectId, int fileId, @Nullable String extension) {
+        return "curse.maven:" + slug + "-" + projectId + ":" + fileId + (extension == null ? "" : "@" + extension);
     }
 
     public static String getSlug(int projectId) {

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDepPlugin.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDepPlugin.java
@@ -1,0 +1,44 @@
+package io.github.noeppi_noeppi.tools.modgradle.plugins.cursedep;
+
+import io.github.noeppi_noeppi.tools.cursewrapper.api.CurseWrapper;
+import net.minecraftforge.gradle.userdev.DependencyManagementExtension;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+import java.io.IOException;
+import java.net.URI;
+
+public class CurseDepPlugin implements Plugin<Project> {
+
+    private static final CurseWrapper API = new CurseWrapper(URI.create("https://curse.melanx.de/"));
+
+    @Override
+    public void apply(Project project) {
+        project.getRepositories().maven(r -> {
+            r.setUrl("https://cfa2.cursemaven.com");
+            r.content(c -> c.includeGroup("curse.maven"));
+        });
+        DependencyManagementExtension ext = getDepExt(project);
+        project.getExtensions().create(CurseDependencyExtension.EXTENSION_NAME, CurseDependencyExtension.class, project, ext);
+    }
+
+    private static DependencyManagementExtension getDepExt(Project project) {
+        return project.getExtensions().getByType(DependencyManagementExtension.class);
+    }
+
+    public static String curseArtifact(int projectId, int fileId) {
+        return curseArtifact(getSlug(projectId), projectId, fileId);
+    }
+
+    public static String curseArtifact(String slug, int projectId, int fileId) {
+        return "curse.maven:" + slug + "-" + projectId + ":" + fileId;
+    }
+
+    public static String getSlug(int projectId) {
+        try {
+            return API.getSlug(projectId);
+        } catch (IOException e) {
+            return "unknown";
+        }
+    }
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDepPlugin.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDepPlugin.java
@@ -1,22 +1,19 @@
 package io.github.noeppi_noeppi.tools.modgradle.plugins.cursedep;
 
-import io.github.noeppi_noeppi.tools.cursewrapper.api.CurseWrapper;
+import io.github.noeppi_noeppi.tools.modgradle.util.CurseUtil;
 import net.minecraftforge.gradle.userdev.DependencyManagementExtension;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.net.URI;
 
 public class CurseDepPlugin implements Plugin<Project> {
-
-    private static final CurseWrapper API = new CurseWrapper(URI.create("https://curse.melanx.de/"));
 
     @Override
     public void apply(Project project) {
         project.getRepositories().maven(r -> {
-            r.setUrl("https://cfa2.cursemaven.com");
+            r.setUrl(CurseUtil.CURSE_MAVEN_URL);
             r.content(c -> c.includeGroup("curse.maven"));
         });
         DependencyManagementExtension ext = getDepExt(project);
@@ -41,7 +38,7 @@ public class CurseDepPlugin implements Plugin<Project> {
 
     public static String getSlug(int projectId) {
         try {
-            return API.getSlug(projectId);
+            return CurseUtil.API.getSlug(projectId);
         } catch (IOException e) {
             return "unknown";
         }

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDependencyExtension.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDependencyExtension.java
@@ -1,0 +1,106 @@
+package io.github.noeppi_noeppi.tools.modgradle.plugins.cursedep;
+
+import com.google.common.collect.Sets;
+import com.google.gson.JsonElement;
+import groovy.lang.GroovyObjectSupport;
+import io.github.noeppi_noeppi.tools.modgradle.ModGradle;
+import net.minecraftforge.gradle.common.util.MavenArtifactDownloader;
+import net.minecraftforge.gradle.userdev.DependencyManagementExtension;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public class CurseDependencyExtension extends GroovyObjectSupport {
+
+    public static final String EXTENSION_NAME = "curse";
+
+    private final Project project;
+
+    @Nullable
+    private final DependencyManagementExtension ext;
+
+    public CurseDependencyExtension(Project project, @Nullable DependencyManagementExtension ext) {
+        this.project = project;
+        this.ext = ext;
+    }
+
+    public Dependency mod(int projectId, int fileId) {
+        return this.createDependency(CurseDepPlugin.curseArtifact(projectId, fileId));
+    }
+
+    public Dependency pack(int projectId, int fileId) {
+        return this.pack(projectId, fileId, Collections.emptyList());
+    }
+
+    public Dependency pack(int projectId, int fileId, List<Object> excludes) {
+        Set<Integer> idExcludes = Sets.newHashSet();
+        Set<String> slugExcludes = Sets.newHashSet();
+
+        for (Object exclude : excludes) {
+            if (exclude instanceof Integer id) {
+                idExcludes.add(id);
+            } else if (exclude instanceof String slug) {
+                slugExcludes.add(slug);
+            } else {
+                throw new IllegalStateException("Cannot add curse ModPack dependency: Excludes must be int (project id) or String (slug). Currently: " + exclude.getClass().getName());
+            }
+        }
+
+        String configName = "cursepack_" + projectId + "_" + fileId + "_" + idExcludes.stream().sorted().map(Object::toString).collect(Collectors.joining("_")) + "_" + slugExcludes.stream().sorted().collect(Collectors.joining("_"));
+        Configuration cache = this.project.getConfigurations().findByName(configName);
+        if (cache != null) {
+            return this.project.getDependencies().create(cache);
+        }
+
+        File file = MavenArtifactDownloader.download(this.project, CurseDepPlugin.curseArtifact("cursepack", projectId, fileId), false);
+        if (file == null) {
+            throw new IllegalStateException("Cannot create curse ModPack dependency: Failed to download manifest");
+        } else try {
+            ZipFile zipFile = new ZipFile(file);
+            ZipEntry entry = zipFile.getEntry("manifest.json");
+            if (entry == null) entry = zipFile.getEntry("/manifest.json");
+            if (entry == null) {
+                throw new IllegalStateException("Cannot create curse ModPack dependency: Pack file contains no manifest");
+            }
+
+            InputStreamReader reader = new InputStreamReader(zipFile.getInputStream(entry));
+            JsonElement json = ModGradle.GSON.fromJson(reader, JsonElement.class);
+            reader.close();
+            Configuration config = this.project.getConfigurations().create(configName);
+
+            for (JsonElement fileJson : json.getAsJsonObject().get("files").getAsJsonArray()) {
+                int p = fileJson.getAsJsonObject().get("projectID").getAsInt();
+                if (!idExcludes.contains(p)) {
+                    int f = fileJson.getAsJsonObject().get("fileID").getAsInt();
+                    String slug = CurseDepPlugin.getSlug(p);
+                    if (!slugExcludes.contains(slug)) {
+                        config.getDependencies().add(this.createDependency(CurseDepPlugin.curseArtifact(slug, p, f)));
+                    }
+                }
+            }
+
+            return this.project.getDependencies().create(config);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot create curse ModPack dependency: " + e.getMessage(), e);
+        }
+    }
+
+    private Dependency createDependency(Object obj) {
+        if (this.ext == null) {
+            return this.project.getDependencies().create(obj);
+        }
+
+        return this.ext.deobf(obj);
+    }
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDependencyExtension.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/cursedep/CurseDependencyExtension.java
@@ -63,7 +63,7 @@ public class CurseDependencyExtension extends GroovyObjectSupport {
             return this.project.getDependencies().create(cache);
         }
 
-        File file = MavenArtifactDownloader.download(this.project, CurseDepPlugin.curseArtifact("cursepack", projectId, fileId), false);
+        File file = MavenArtifactDownloader.download(this.project, CurseDepPlugin.curseArtifact("O", projectId, fileId, "zip"), false);
         if (file == null) {
             throw new IllegalStateException("Cannot create curse ModPack dependency: Failed to download manifest");
         } else try {

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/mcupdate/task/ExtractLocalTask.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/mcupdate/task/ExtractLocalTask.java
@@ -2,11 +2,13 @@ package io.github.noeppi_noeppi.tools.modgradle.plugins.mcupdate.task;
 
 import io.github.noeppi_noeppi.tools.modgradle.ModGradle;
 import net.minecraftforge.gradle.common.tasks.JarExec;
-import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.*;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputFile;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/mcupdate/task/StageLocalTask.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/mcupdate/task/StageLocalTask.java
@@ -5,7 +5,6 @@ import net.minecraftforge.gradle.common.tasks.JarExec;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/CurseFile.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/CurseFile.java
@@ -12,7 +12,7 @@ import io.github.noeppi_noeppi.tools.modgradle.util.Side;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -21,8 +21,8 @@ import java.util.Map;
 
 public record CurseFile(int projectId, int fileId, Side side) {
 
-    public URL downloadUrl() throws IOException {
-        return new URL("https://www.cursemaven.com/curse/maven/O-" + this.projectId + "/" + this.fileId + "/O-" + this.projectId + "-" + this.fileId + ".jar");
+    public URI downloadUrl() throws IOException {
+        return CurseUtil.curseMaven("/curse/maven/O-" + this.projectId + "/" + this.fileId + "/O-" + this.projectId + "-" + this.fileId + ".jar");
     }
 
     public String fileName() throws IOException {

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/CurseFile.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/CurseFile.java
@@ -1,0 +1,81 @@
+package io.github.noeppi_noeppi.tools.modgradle.plugins.packdev;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.github.noeppi_noeppi.tools.modgradle.ModGradle;
+import io.github.noeppi_noeppi.tools.modgradle.util.CurseUtil;
+import io.github.noeppi_noeppi.tools.modgradle.util.Side;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.Map;
+
+public record CurseFile(int projectId, int fileId, Side side) {
+
+    public URL downloadUrl() throws IOException {
+        return new URL("https://www.cursemaven.com/curse/maven/O-" + this.projectId + "/" + this.fileId + "/O-" + this.projectId + "-" + this.fileId + ".jar");
+    }
+
+    public String fileName() throws IOException {
+        return CurseUtil.API.getFile(this.projectId, this.fileId).name();
+    }
+
+    public static CurseFile parse(JsonObject json) {
+        int projectId = json.get("project").getAsInt();
+        int fileId = json.get("file").getAsInt();
+        Side side = Side.byId(json.get("side").getAsString());
+        return new CurseFile(projectId, fileId, side);
+    }
+
+    public static List<CurseFile> parseFiles(JsonElement json) {
+        ImmutableList.Builder<CurseFile> list = ImmutableList.builder();
+        for (JsonElement element : json.getAsJsonArray()) {
+            list.add(CurseFile.parse(element.getAsJsonObject()));
+        }
+
+        return list.build();
+    }
+
+    public static Map<Integer, Integer> readCache(Path path) throws IOException {
+        if (Files.isRegularFile(path)) {
+            BufferedReader reader = Files.newBufferedReader(path);
+            JsonArray array = ModGradle.INTERNAL.fromJson(reader, JsonArray.class);
+            reader.close();
+            ImmutableMap.Builder<Integer, Integer> map = ImmutableMap.builder();
+
+            for (JsonElement element : array) {
+                map.put(
+                        element.getAsJsonObject().get("project").getAsInt(),
+                        element.getAsJsonObject().get("file").getAsInt()
+                );
+            }
+
+            return map.build();
+        } else {
+            return Map.of();
+        }
+    }
+
+    public static void writeCache(Path path, List<CurseFile> files) throws IOException {
+        JsonArray array = new JsonArray();
+        for (CurseFile file : files) {
+            JsonObject json = new JsonObject();
+            json.addProperty("project", file.projectId);
+            json.addProperty("file", file.fileId);
+            array.add(json);
+        }
+
+        BufferedWriter writer = Files.newBufferedWriter(path, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        writer.write(ModGradle.INTERNAL.toJson(array) + "\n");
+        writer.close();
+    }
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/PackDevExtension.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/PackDevExtension.java
@@ -1,0 +1,52 @@
+package io.github.noeppi_noeppi.tools.modgradle.plugins.packdev;
+
+import com.google.common.collect.ImmutableList;
+import groovy.lang.GroovyObjectSupport;
+import groovy.transform.Internal;
+import io.github.noeppi_noeppi.tools.modgradle.util.McEnv;
+import org.gradle.api.Project;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public class PackDevExtension extends GroovyObjectSupport {
+
+    public static final String EXTENSION_NAME = "modpack";
+
+    private final Project project;
+    private final List<String> editions = new ArrayList<>();
+
+    private int projectId = -1;
+    private String author;
+
+    public PackDevExtension(Project project) {
+        this.project = project;
+    }
+
+    public void projectId(int projectId) {
+        this.projectId = projectId;
+    }
+
+    public void author(String author) {
+        this.author = author;
+    }
+
+    public void edition(String edition) {
+        this.editions.add(edition);
+    }
+
+    @Internal
+    public PackSettings getSettings() {
+        String minecraft = McEnv.findMinecraftVersion(this.project).get();
+        String forge = McEnv.findForgeVersion(this.project).get();
+        if (this.projectId < 0) throw new IllegalStateException("Curse project id not set.");
+        return new PackSettings(
+                Objects.requireNonNull(minecraft, "Minecraft version not set."),
+                Objects.requireNonNull(forge, "Forge version not set."),
+                this.projectId, Optional.ofNullable(this.author),
+                ImmutableList.copyOf(this.editions)
+        );
+    }
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/PackDevPlugin.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/PackDevPlugin.java
@@ -45,7 +45,7 @@ public class PackDevPlugin implements Plugin<Project> {
             throw new IllegalStateException("The PackDev plugin requires the ModGradle mapping plugin.");
 
         project.getRepositories().maven(r -> {
-            r.setUrl(CurseUtil.CURSE_MAVEN_URL);
+            r.setUrl(CurseUtil.CURSE_MAVEN);
             r.content(c -> c.includeGroup("curse.maven"));
         });
 

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/PackDevPlugin.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/PackDevPlugin.java
@@ -1,0 +1,208 @@
+package io.github.noeppi_noeppi.tools.modgradle.plugins.packdev;
+
+import com.google.gson.JsonElement;
+import io.github.noeppi_noeppi.tools.modgradle.ModGradle;
+import io.github.noeppi_noeppi.tools.modgradle.api.Versioning;
+import io.github.noeppi_noeppi.tools.modgradle.plugins.cursedep.CurseDepPlugin;
+import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.task.BuildCursePackTask;
+import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.task.BuildModrinthPackTask;
+import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.task.BuildServerPackTask;
+import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.task.BuildTargetTask;
+import io.github.noeppi_noeppi.tools.modgradle.util.CurseUtil;
+import io.github.noeppi_noeppi.tools.modgradle.util.JavaEnv;
+import io.github.noeppi_noeppi.tools.modgradle.util.MgUtil;
+import io.github.noeppi_noeppi.tools.modgradle.util.Side;
+import net.minecraftforge.gradle.userdev.UserDevExtension;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.tasks.Copy;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Consumer;
+
+public class PackDevPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        if (!project.getPlugins().hasPlugin("net.minecraftforge.gradle"))
+            throw new IllegalStateException("The PackDev plugin requires the ForgeGradle userdev plugin.");
+        if (!project.getPlugins().hasPlugin("io.github.noeppi_noeppi.tools.modgradle.mapping"))
+            throw new IllegalStateException("The PackDev plugin requires the ModGradle mapping plugin.");
+
+        project.getRepositories().maven(r -> {
+            r.setUrl(CurseUtil.CURSE_MAVEN_URL);
+            r.content(c -> c.includeGroup("curse.maven"));
+        });
+
+        try {
+            for (Side side : Side.values()) {
+                if (!Files.exists(project.file("data").toPath().resolve(side.id))) {
+                    Files.createDirectories(project.file("data").toPath().resolve(side.id));
+                }
+            }
+
+            if (!Files.exists(project.file("modlist.json").toPath())) {
+                Writer writer = Files.newBufferedWriter(project.file("modlist.json").toPath(), StandardOpenOption.CREATE_NEW);
+                writer.write("[]\n");
+                writer.close();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        Configuration clientMods = project.getConfigurations().create("clientMods", c -> {
+            c.setCanBeConsumed(false);
+            c.setCanBeResolved(true);
+        });
+        Configuration serverMods = project.getConfigurations().create("serverMods", c -> {
+            c.setCanBeConsumed(false);
+            c.setCanBeResolved(true);
+        });
+        Configuration compileOnly = project.getConfigurations().getByName("compileOnly");
+        compileOnly.extendsFrom(clientMods, serverMods);
+
+        SourceSetContainer sourceSets = JavaEnv.getJavaExtension(project).get().getSourceSets();
+        sourceSets.create("data", set -> {
+            set.getJava().setSrcDirs(List.of());
+            set.getResources().setSrcDirs(List.of(
+                    project.file("data/" + Side.COMMON.id),
+                    project.file("data/" + Side.CLIENT.id),
+                    project.file("data/" + Side.SERVER.id)
+            ));
+        });
+
+        SourceSet clientDepSources = sourceSets.create("modpack_dependency_client", set -> {
+            set.getJava().setSrcDirs(List.of());
+            set.getResources().setSrcDirs(List.of());
+            set.setRuntimeClasspath(clientMods);
+        });
+
+        SourceSet serverDepSources = sourceSets.create("modpack_dependency_server", set -> {
+            set.getJava().setSrcDirs(List.of());
+            set.getResources().setSrcDirs(List.of());
+            set.setRuntimeClasspath(serverMods);
+        });
+
+        UserDevExtension mcExt = getMcExt(project);
+        mcExt.mappings("none", "none");
+        addRunConfig(project, mcExt, "client", Side.CLIENT, JavaEnv.getJavaSources(project).get(), clientDepSources);
+        addRunConfig(project, mcExt, "server", Side.SERVER, JavaEnv.getJavaSources(project).get(), serverDepSources);
+
+        PackDevExtension ext = project.getExtensions().create(PackDevExtension.EXTENSION_NAME, PackDevExtension.class);
+        project.afterEvaluate(p -> {
+            PackSettings settings = ext.getSettings();
+            JavaEnv.getJavaExtension(project).get().getToolchain().getLanguageVersion().set(JavaLanguageVersion.of(Versioning.getJavaVersion(settings.minecraft())));
+
+            try {
+                for (Path path : Arrays.stream(Side.values()).map(side -> project.file("data/" + side.id).toPath()).filter(Files::notExists).toList()) {
+                    Files.createDirectories(path);
+                }
+                for (String edition : settings.editions()) {
+                    for (Path path : Arrays.stream(Side.values()).map(side -> project.file("data-" + edition + "/" + side.id).toPath()).filter(Files::notExists).toList()) {
+                        Files.createDirectories(path);
+                    }
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to load modlist", e);
+            }
+
+            List<CurseFile> files;
+            try {
+                Reader reader = Files.newBufferedReader(project.file("modlist.json").toPath());
+                files = CurseFile.parseFiles(ModGradle.GSON.fromJson(reader, JsonElement.class));
+                reader.close();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to load modlist", e);
+            }
+
+            for (CurseFile file : files) {
+                String cfg = switch (file.side()) {
+                    case COMMON -> "implementation";
+                    case CLIENT -> "clientMods";
+                    case SERVER -> "serverMods";
+                };
+                project.getDependencies().add(cfg, CurseDepPlugin.curseArtifact(file.projectId(), file.fileId()));
+            }
+
+            forEditions(settings, edition -> {
+                addBuildTask(project, BuildCursePackTask.class, edition, "curse", settings, files);
+                addBuildTask(project, BuildServerPackTask.class, edition, "server", settings, files);
+                addBuildTask(project, BuildModrinthPackTask.class, edition, "modrinth", settings, files);
+            });
+        });
+    }
+
+    private static UserDevExtension getMcExt(Project project) {
+        try {
+            return project.getExtensions().getByType(UserDevExtension.class);
+        } catch (Exception e) {
+            throw new IllegalStateException("minecraft extension not found.");
+        }
+    }
+
+    private static void forEditions(PackSettings settings, Consumer<String> action) {
+        action.accept(null);
+        settings.editions().forEach(action);
+    }
+
+    private static void addRunConfig(Project project, UserDevExtension ext, String name, Side side, SourceSet commonMods, SourceSet additionalMods) {
+        String capitalized = name.substring(0, 1).toLowerCase(Locale.ROOT) + name.substring(1);
+        String taskName = "run" + capitalized;
+        File workingDir = project.file(taskName);
+        ext.getRuns().create(name, run -> {
+            run.workingDirectory(workingDir);
+            run.property("forge.logging.console.level", "info");
+            run.jvmArg("-Dproduction=true");
+            run.getMods().create("packdev_dummy_mod", mod -> {
+                mod.source(commonMods);
+                mod.source(additionalMods);
+            });
+        });
+
+        Copy copyTask = project.getTasks().create("copy" + capitalized + "Data", Copy.class);
+        copyTask.setDestinationDir(workingDir);
+        copyTask.from(project.fileTree("data/" + Side.COMMON.id));
+        if (side != Side.COMMON) copyTask.from(project.fileTree("data/" + side.id));
+        // Create some directories because Forge 1.17+ requires it
+        JavaCompile jc = MgUtil.task(project, "compileJava", JavaCompile.class);
+        if (jc == null) throw new IllegalStateException("Cannot set up PackDev run config: compileJava task not found");
+        copyTask.doLast(t -> {
+            try {
+                Files.createDirectories(jc.getDestinationDirectory().getAsFile().get().toPath());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        project.getGradle().projectsEvaluated(g -> {
+            Task prepareRunsTask = project.getTasks().getByName("prepareRuns");
+            prepareRunsTask.dependsOn(copyTask);
+        });
+    }
+
+    private static void addBuildTask(Project project, Class<? extends BuildTargetTask> taskCls, String edition, String classifier, PackSettings settings, List<CurseFile> files) {
+        String editionPrefix = edition == null ? "" : edition + "-";
+        String capitalizedClassifier = classifier.substring(0, 1).toUpperCase(Locale.ROOT) + classifier.substring(1);
+        String capitalizedEdition = edition == null || edition.isEmpty() ? "" : edition.substring(0, 1).toUpperCase(Locale.ROOT) + edition.substring(1);
+        BuildTargetTask task = project.getTasks().create("build" + capitalizedEdition + capitalizedClassifier + "Pack", taskCls, settings, files, edition == null ? "" : edition);
+        task.getArchiveClassifier().convention(editionPrefix + classifier);
+        task.getDestinationDirectory().set(project.file("build").toPath().resolve("target").toFile());
+        Task buildTask = MgUtil.task(project, "build", Task.class);
+        if (buildTask != null) buildTask.dependsOn(task);
+    }
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/PackSettings.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/PackSettings.java
@@ -1,0 +1,11 @@
+package io.github.noeppi_noeppi.tools.modgradle.plugins.packdev;
+
+import java.util.List;
+import java.util.Optional;
+
+public record PackSettings(String minecraft,
+                           String forge,
+                           int projectId,
+                           Optional<String> author,
+                           List<String> editions) {
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildCursePackTask.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildCursePackTask.java
@@ -89,7 +89,7 @@ public class BuildCursePackTask extends BuildTargetTask {
             String name = info.name();
             String slug = info.slug();
             String author = "<a href=\"https://www.curseforge.com/members/" + info.owner() + "/projects\">" + info.owner() + "</a>";
-            linesBySlug.put(slug, "<li><a href=\"https://www.curseforge.com/projects/" + file.projectId() + "\">" + name + "</a>" + author + "</li>");
+            linesBySlug.put(slug, "<li><a href=\"" + info.website() + "\">" + name + "</a>" + author + "</li>");
         }
         Writer writer = Files.newBufferedWriter(target, StandardOpenOption.CREATE_NEW);
         writer.write("<h2>" + this.getProject().getName() + " - " + this.getProject().getVersion() + "</h2>\n");

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildCursePackTask.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildCursePackTask.java
@@ -1,0 +1,104 @@
+package io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.task;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import io.github.noeppi_noeppi.tools.cursewrapper.api.response.ProjectInfo;
+import io.github.noeppi_noeppi.tools.modgradle.ModGradle;
+import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.CurseFile;
+import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.PackSettings;
+import io.github.noeppi_noeppi.tools.modgradle.util.CurseUtil;
+import io.github.noeppi_noeppi.tools.modgradle.util.Side;
+import org.apache.commons.io.file.PathUtils;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.Writer;
+import java.net.URI;
+import java.nio.file.*;
+import java.util.*;
+
+public class BuildCursePackTask extends BuildTargetTask {
+
+    @Inject
+    public BuildCursePackTask(PackSettings settings, List<CurseFile> files, String edition) {
+        super(settings, files, edition);
+    }
+
+    @Override
+    protected void generate(Path target) throws IOException {
+        FileSystem fs = FileSystems.newFileSystem(URI.create("jar:" + target.toUri()), Map.of(
+                "create", String.valueOf(!Files.exists(target))
+        ));
+        Files.createDirectories(fs.getPath("overrides"));
+        for (Path src : this.getOverridePaths(Side.CLIENT)) {
+            PathUtils.copyDirectory(src, fs.getPath("overrides"));
+        }
+
+        this.generateManifest(fs.getPath("manifest.json"));
+        this.generateModList(fs.getPath("modlist.html"));
+        fs.close();
+    }
+
+    private void generateManifest(Path target) throws IOException {
+        String capitalizedEdition = this.edition == null ? null : this.edition.substring(0, 1).toUpperCase(Locale.ROOT) + this.edition.substring(1);
+        String editionPart = capitalizedEdition == null ? "" : " (" + capitalizedEdition + ")";
+
+        JsonObject json = new JsonObject();
+
+        JsonObject minecraftBlock = new JsonObject();
+        minecraftBlock.addProperty("version", this.settings.minecraft());
+
+        JsonArray modLoaders = new JsonArray();
+        JsonObject modLoader = new JsonObject();
+        modLoader.addProperty("id", "forge-" + this.settings.forge());
+        modLoader.addProperty("primary", true);
+        modLoaders.add(modLoader);
+
+        minecraftBlock.add("modLoaders", modLoaders);
+        json.add("minecraft", minecraftBlock);
+
+        json.addProperty("manifestType", "minecraftModpack");
+        json.addProperty("overrides", "overrides");
+        json.addProperty("manifestVersion", 1);
+        json.addProperty("version", this.getProject().getVersion().toString());
+        this.settings.author().ifPresent(author -> json.addProperty("author", author));
+        json.addProperty("projectID", this.settings.projectId());
+        json.addProperty("name", this.getProject().getName() + editionPart);
+
+        JsonArray fileArray = new JsonArray();
+        for (CurseFile file : this.files.stream().sorted(Comparator.comparing(CurseFile::projectId)).toList()) {
+            if (file.side().client) {
+                JsonObject fileObj = new JsonObject();
+                fileObj.addProperty("projectID", file.projectId());
+                fileObj.addProperty("fileID", file.fileId());
+                fileArray.add(fileObj);
+            }
+        }
+        json.add("files", fileArray);
+
+        Writer writer = Files.newBufferedWriter(target, StandardOpenOption.CREATE_NEW);
+        writer.write(ModGradle.GSON.toJson(json) + "\n");
+        writer.close();
+    }
+
+    private void generateModList(Path target) throws IOException {
+        Map<String, String> linesBySlug = new HashMap<>();
+        for (CurseFile file : this.files) {
+            ProjectInfo info = CurseUtil.API.getProject(file.projectId());
+
+            String name = info.name();
+            String slug = info.slug();
+            String author = "<a href=\"https://www.curseforge.com/members/" + info.owner() + "/projects\">" + info.owner() + "</a>";
+            linesBySlug.put(slug, "<li><a href=\"https://www.curseforge.com/projects/" + file.projectId() + "\">" + name + "</a>" + author + "</li>");
+        }
+        Writer writer = Files.newBufferedWriter(target, StandardOpenOption.CREATE_NEW);
+        writer.write("<h2>" + this.getProject().getName() + " - " + this.getProject().getVersion() + "</h2>\n");
+        writer.write("\n");
+        writer.write("<ul>\n");
+        for (String line : linesBySlug.entrySet().stream().sorted(Map.Entry.comparingByKey()).map(Map.Entry::getValue).toList()) {
+            writer.write(line + "\n");
+        }
+        writer.write("</ul>\n");
+        writer.close();
+    }
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildModrinthPackTask.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildModrinthPackTask.java
@@ -48,7 +48,7 @@ public class BuildModrinthPackTask extends BuildTargetTask {
         for (CurseFile file : this.files) {
             futures.add(service.submit(() -> {
                 try {
-                    Map<String, String> map = IOUtil.commonHashes(file.downloadUrl().openStream());
+                    Map<String, String> map = IOUtil.commonHashes(file.downloadUrl().toURL().openStream());
                     hashes.put(file, map);
                 } catch (IOException e) {
                     throw new RuntimeException(e);
@@ -80,7 +80,7 @@ public class BuildModrinthPackTask extends BuildTargetTask {
 
         JsonArray fileArray = new JsonArray();
         for (CurseFile file : this.files.stream().sorted(Comparator.comparing(CurseFile::projectId)).toList()) {
-            URL url = file.downloadUrl();
+            URI url = file.downloadUrl();
             JsonObject fileObj = new JsonObject();
             fileObj.addProperty("path", "mods/" + file.fileName());
 

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildModrinthPackTask.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildModrinthPackTask.java
@@ -12,7 +12,6 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.io.Writer;
 import java.net.URI;
-import java.net.URL;
 import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.ExecutionException;

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildModrinthPackTask.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildModrinthPackTask.java
@@ -1,0 +1,112 @@
+package io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.task;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import io.github.noeppi_noeppi.tools.modgradle.ModGradle;
+import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.CurseFile;
+import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.PackSettings;
+import io.github.noeppi_noeppi.tools.modgradle.util.IOUtil;
+import org.apache.commons.io.file.PathUtils;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.Writer;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.*;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+public class BuildModrinthPackTask extends BuildTargetTask {
+
+    @Inject
+    public BuildModrinthPackTask(PackSettings settings, List<CurseFile> files, String edition) {
+        super(settings, files, edition);
+    }
+
+    @Override
+    protected void generate(Path target) throws IOException {
+        FileSystem fs = FileSystems.newFileSystem(URI.create("jar:" + target.toUri()), Map.of(
+                "create", String.valueOf(!Files.exists(target))
+        ));
+        Files.createDirectories(fs.getPath("overrides"));
+        for (Path src : this.getOverridePaths(null)) {
+            PathUtils.copyDirectory(src, fs.getPath("overrides"));
+        }
+        this.generateIndex(fs.getPath("index.json"));
+        fs.close();
+    }
+
+    private void generateIndex(Path target) throws IOException {
+        // First compute hashes async
+        ScheduledExecutorService service = new ScheduledThreadPoolExecutor(Math.max(1, Runtime.getRuntime().availableProcessors() - 1));
+        Map<CurseFile, Map<String, String>> hashes = Collections.synchronizedMap(new HashMap<>());
+        List<Future<?>> futures = new ArrayList<>();
+        for (CurseFile file : this.files) {
+            futures.add(service.submit(() -> {
+                try {
+                    Map<String, String> map = IOUtil.commonHashes(file.downloadUrl().openStream());
+                    hashes.put(file, map);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+        }
+        for (Future<?> future : futures) {
+            try {
+                future.get();
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        String capitalizedEdition = this.edition == null ? null : this.edition.substring(0, 1).toUpperCase(Locale.ROOT) + this.edition.substring(1);
+        String editionPart = capitalizedEdition == null ? "" : " (" + capitalizedEdition + ")";
+
+        JsonObject json = new JsonObject();
+
+        json.addProperty("formatVersion", 1);
+        json.addProperty("game", "minecraft");
+        json.addProperty("name", this.getProject().getName() + editionPart);
+        json.addProperty("versionId", this.getProject().getVersion().toString());
+
+        JsonObject dependencies = new JsonObject();
+        dependencies.addProperty("minecraft", this.settings.minecraft());
+        dependencies.addProperty("forge", this.settings.forge());
+        json.add("dependencies", dependencies);
+
+        JsonArray fileArray = new JsonArray();
+        for (CurseFile file : this.files.stream().sorted(Comparator.comparing(CurseFile::projectId)).toList()) {
+            URL url = file.downloadUrl();
+            JsonObject fileObj = new JsonObject();
+            fileObj.addProperty("path", "mods/" + file.fileName());
+
+            JsonArray downloadArray = new JsonArray();
+            downloadArray.add(url.toString());
+            fileObj.add("downloads", downloadArray);
+
+            JsonObject env = new JsonObject();
+            env.addProperty("client", file.side().client ? "required" : "unsupported");
+            env.addProperty("server", file.side().server ? "required" : "unsupported");
+            fileObj.add("env", env);
+
+            JsonObject hashesObj = new JsonObject();
+            if (hashes.containsKey(file)) {
+                for (Map.Entry<String, String> entry : hashes.get(file).entrySet()) {
+                    hashesObj.addProperty(entry.getKey(), entry.getValue());
+                }
+            }
+            fileObj.add("hashes", hashesObj);
+
+            fileArray.add(fileObj);
+        }
+        json.add("files", fileArray);
+
+        Writer writer = Files.newBufferedWriter(target, StandardOpenOption.CREATE_NEW);
+        writer.write(ModGradle.GSON.toJson(json) + "\n");
+        writer.close();
+    }
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildServerPackTask.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildServerPackTask.java
@@ -1,0 +1,74 @@
+package io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.task;
+
+import io.github.noeppi_noeppi.tools.modgradle.api.Versioning;
+import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.CurseFile;
+import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.PackDevPlugin;
+import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.PackSettings;
+import io.github.noeppi_noeppi.tools.modgradle.util.IOUtil;
+import io.github.noeppi_noeppi.tools.modgradle.util.Side;
+import org.apache.commons.io.file.PathUtils;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Writer;
+import java.net.URI;
+import java.nio.file.*;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.*;
+
+public class BuildServerPackTask extends BuildTargetTask {
+
+    @Inject
+    public BuildServerPackTask(PackSettings settings, List<CurseFile> files, String edition) {
+        super(settings, files, edition);
+    }
+
+    @Override
+    protected void generate(Path target) throws IOException {
+        FileSystem fs = FileSystems.newFileSystem(URI.create("jar:" + target.toUri()), Map.of(
+                "create", String.valueOf(!Files.exists(target))
+        ));
+        for (Path src : this.getOverridePaths(Side.SERVER)) {
+            PathUtils.copyDirectory(src, fs.getPath(""));
+        }
+
+        InputStream installScript = PackDevPlugin.class.getResourceAsStream("/" + PackDevPlugin.class.getPackage().getName().replace('.', '/') + "/install_server.py");
+        if (installScript == null)
+            throw new IllegalStateException("Can't build server pack: Install script not found in ModGradle.");
+        Files.copy(installScript, fs.getPath("install.py"));
+        installScript.close();
+
+        try {
+            Set<PosixFilePermission> perms = new HashSet<>(Files.getPosixFilePermissions(fs.getPath("install.py")));
+            perms.add(PosixFilePermission.OWNER_EXECUTE);
+            perms.add(PosixFilePermission.GROUP_EXECUTE);
+            perms.add(PosixFilePermission.OTHERS_EXECUTE);
+            Files.setPosixFilePermissions(fs.getPath("install.py"), perms);
+        } catch (Exception e) {
+            //
+        }
+
+        InputStream dockerFile = PackDevPlugin.class.getResourceAsStream("/" + PackDevPlugin.class.getPackage().getName().replace('.', '/') + "/Dockerfile");
+        if (dockerFile == null)
+            throw new IllegalStateException("Can't build server pack: Dockerfile not found in ModGradle.");
+        IOUtil.copyFile(dockerFile, fs.getPath("Dockerfile"), Map.of(
+                "jdk", Integer.toString(Versioning.getJavaVersion(this.settings.minecraft()))
+        ), true);
+        dockerFile.close();
+
+        this.generateServerInfo(fs.getPath("server.txt"));
+        fs.close();
+    }
+
+    private void generateServerInfo(Path target) throws IOException {
+        Writer writer = Files.newBufferedWriter(target, StandardOpenOption.CREATE_NEW);
+        writer.write(this.settings.minecraft() + "/" + this.settings.forge() + "\n");
+        for (CurseFile file : this.files.stream().sorted(Comparator.comparing(CurseFile::projectId)).toList()) {
+            if (file.side().server) {
+                writer.write(file.projectId() + "/" + file.fileId() + "\n");
+            }
+        }
+        writer.close();
+    }
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildTargetTask.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildTargetTask.java
@@ -1,0 +1,108 @@
+package io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.task;
+
+import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.CurseFile;
+import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.PackSettings;
+import io.github.noeppi_noeppi.tools.modgradle.util.Side;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.file.copy.CopyAction;
+import org.gradle.api.internal.provider.DefaultProvider;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.bundling.AbstractArchiveTask;
+import org.gradle.work.InputChanges;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class BuildTargetTask extends AbstractArchiveTask {
+
+    protected final PackSettings settings;
+    protected final List<CurseFile> files;
+
+    @Nullable
+    protected final String edition;
+
+    private final Property<FileCollection> inputData = this.getProject().getObjects().property(FileCollection.class);
+
+    @Inject
+    public BuildTargetTask(PackSettings settings, List<CurseFile> files, String edition) {
+        this.settings = settings;
+        this.files = files;
+        this.edition = edition.isEmpty() ? null : edition;
+
+        this.getArchiveBaseName().convention(new DefaultProvider<>(this.getProject()::getName));
+        this.getArchiveVersion().convention(new DefaultProvider<>(() -> this.getProject().getVersion().toString()));
+        this.getArchiveClassifier().convention(new DefaultProvider<>(() -> ""));
+        this.getArchiveExtension().convention(new DefaultProvider<>(() -> "zip"));
+
+        this.inputData.convention(new DefaultProvider<>(() -> this.getProject().files(
+                this.getProject().file("modlist.json"),
+                this.getProject().file("data/" + Side.COMMON.id),
+                this.getProject().file("data/" + Side.CLIENT.id),
+                this.getProject().file("data/" + Side.SERVER.id)
+        )));
+        // We need dummy sources, or it will always skip with NO-SOURCE
+        this.from(this.inputData);
+    }
+
+    @InputFiles
+    public FileCollection getInputData() {
+        return this.inputData.get();
+    }
+
+    public void setInputData(FileCollection inputMods) {
+        this.inputData.set(inputMods);
+    }
+
+    @Nonnull
+    @Override
+    protected CopyAction createCopyAction() {
+        // Do nothing
+        return copy -> () -> true;
+    }
+
+    @TaskAction
+    public void generateOutput(InputChanges changes) throws IOException {
+        Path target = this.getArchiveFile().get().getAsFile().toPath();
+        if (!Files.exists(target.getParent())) Files.createDirectories(target.getParent());
+        if (Files.exists(target)) Files.delete(target);
+        this.generate(target);
+    }
+
+    protected abstract void generate(Path target) throws IOException;
+
+    // Elements later in the list should overwrite
+    // Null means everything
+    protected final List<Path> getOverridePaths(@Nullable Side side) {
+        List<Path> list = new ArrayList<>();
+        if (side != null) {
+            list.add(this.getProject().file("data/" + Side.COMMON.id).toPath());
+            if (side != Side.COMMON) list.add(this.getProject().file("data/" + side.id).toPath());
+        } else {
+            list.add(this.getProject().file("data/" + Side.COMMON.id).toPath());
+            list.add(this.getProject().file("data/" + Side.SERVER.id).toPath());
+            list.add(this.getProject().file("data/" + Side.CLIENT.id).toPath());
+        }
+
+        if (this.edition != null) {
+            if (side != null) {
+                list.add(this.getProject().file("data- " + this.edition + "/" + Side.COMMON.id).toPath());
+                if (side != Side.COMMON)
+                    list.add(this.getProject().file("data- " + this.edition + "/" + side.id).toPath());
+            } else {
+                list.add(this.getProject().file("data- " + this.edition + "/" + Side.COMMON.id).toPath());
+                list.add(this.getProject().file("data- " + this.edition + "/" + Side.SERVER.id).toPath());
+                list.add(this.getProject().file("data- " + this.edition + "/" + Side.CLIENT.id).toPath());
+            }
+        }
+
+        return list.stream().filter(Files::isDirectory).toList();
+    }
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/sourcejar/MergeJarWithSourcesTask.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/sourcejar/MergeJarWithSourcesTask.java
@@ -9,7 +9,10 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.*;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.work.InputChanges;
 

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/CurseUtil.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/CurseUtil.java
@@ -1,0 +1,11 @@
+package io.github.noeppi_noeppi.tools.modgradle.util;
+
+import io.github.noeppi_noeppi.tools.cursewrapper.api.CurseWrapper;
+
+import java.net.URI;
+
+public class CurseUtil {
+
+    public static final CurseWrapper API = new CurseWrapper(URI.create("https://curse.melanx.de/"));
+    public static final String CURSE_MAVEN_URL = "https://cfa2.cursemaven.com";
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/CurseUtil.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/CurseUtil.java
@@ -7,5 +7,9 @@ import java.net.URI;
 public class CurseUtil {
 
     public static final CurseWrapper API = new CurseWrapper(URI.create("https://curse.melanx.de/"));
-    public static final String CURSE_MAVEN_URL = "https://cfa2.cursemaven.com";
+    public static final URI CURSE_MAVEN = URI.create("https://cfa2.cursemaven.com");
+
+    public static URI curseMaven(String endpoint) {
+        return CURSE_MAVEN.resolve(endpoint.startsWith("/") ? endpoint : "/" + endpoint);
+    }
 }

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/IOUtil.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/IOUtil.java
@@ -4,7 +4,10 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.commons.io.IOUtils;
 
 import javax.annotation.WillClose;
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.math.BigInteger;
 import java.net.URI;
 import java.nio.file.*;

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/task/ExtractInheritanceTask.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/task/ExtractInheritanceTask.java
@@ -2,7 +2,9 @@ package io.github.noeppi_noeppi.tools.modgradle.util.task;
 
 import io.github.noeppi_noeppi.tools.modgradle.ModGradle;
 import net.minecraftforge.gradle.common.tasks.JarExec;
-import org.gradle.api.file.*;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;

--- a/plugin/src/main/resources/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/install_server.py
+++ b/plugin/src/main/resources/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/install_server.py
@@ -9,6 +9,14 @@ import subprocess
 import urllib.parse
 from urllib.request import Request, urlopen
 
+headers = {'Accept': 'application/json', 'User-Agent': 'python3/modgradle server installer'}
+
+
+def get_file_name(project_id, file_id):
+    file_info = Request(f'https://curse.melanx.de/project/{project_id}/file/{file_id}', headers=headers)
+    data = json.loads(urlopen(file_info).read().decode('utf-8'))
+    return data["name"]
+
 
 def setup_server():
     mods = []
@@ -26,7 +34,8 @@ def setup_server():
     print('Installing Forge')
     mcv = mods[0][0]
     mlv = mods[0][1]
-    request = Request(f'https://maven.minecraftforge.net/net/minecraftforge/forge/{mcv}-{mlv}/forge-{mcv}-{mlv}-installer.jar')
+    request = Request(
+        f'https://maven.minecraftforge.net/net/minecraftforge/forge/{mcv}-{mlv}/forge-{mcv}-{mlv}-installer.jar')
 
     response = urlopen(request)
     with open('installer.jar', mode='wb') as file:
@@ -74,15 +83,13 @@ def setup_server():
     for mod in mods[1:]:
         project_id = mod[0]
         file_id = mod[1]
-        download_url = f'https://addons-ecs.forgesvc.net/api/v2/addon/{project_id}/file/{file_id}/download-url'
-        request1 = Request(download_url)
-        response1 = urlopen(request1)
-        file_url = response1.read().decode('utf-8')
-        request2 = Request(urllib.parse.quote(file_url, safe="/:@?=&"))
-        response2 = urlopen(request2)
-        print('Downloading mod %s...' % file_url[file_url.rfind('/') + 1:])
-        with open('mods' + os.path.sep + file_url[file_url.rfind('/') + 1:], mode='wb') as target:
-            target.write(response2.read())
+        download_url = f'https://cfa2.cursemaven.com/curse/maven/O-{project_id}/{file_id}/O-{project_id}-{file_id}.jar'
+        file_name = get_file_name(project_id, file_id)
+        request = Request(urllib.parse.quote(download_url, safe="/:@?=&"), headers=headers)
+        response = urlopen(request)
+        print('Downloading mod %s...' % file_name)
+        with open('mods' + os.path.sep + file_name, mode='wb') as target:
+            target.write(response.read())
 
 
 if __name__ == '__main__':

--- a/plugin/src/main/resources/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/install_server.py
+++ b/plugin/src/main/resources/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/install_server.py
@@ -9,14 +9,6 @@ import subprocess
 import urllib.parse
 from urllib.request import Request, urlopen
 
-headers = {'Accept': 'application/json', 'User-Agent': 'python3/modgradle server installer'}
-
-
-def get_file_name(project_id, file_id):
-    file_info = Request(f'https://curse.melanx.de/project/{project_id}/file/{file_id}', headers=headers)
-    data = json.loads(urlopen(file_info).read().decode('utf-8'))
-    return data["name"]
-
 
 def setup_server():
     mods = []
@@ -34,8 +26,7 @@ def setup_server():
     print('Installing Forge')
     mcv = mods[0][0]
     mlv = mods[0][1]
-    request = Request(
-        f'https://maven.minecraftforge.net/net/minecraftforge/forge/{mcv}-{mlv}/forge-{mcv}-{mlv}-installer.jar')
+    request = Request(f'https://maven.minecraftforge.net/net/minecraftforge/forge/{mcv}-{mlv}/forge-{mcv}-{mlv}-installer.jar')
 
     response = urlopen(request)
     with open('installer.jar', mode='wb') as file:
@@ -85,11 +76,17 @@ def setup_server():
         file_id = mod[1]
         download_url = f'https://cfa2.cursemaven.com/curse/maven/O-{project_id}/{file_id}/O-{project_id}-{file_id}.jar'
         file_name = get_file_name(project_id, file_id)
-        request = Request(urllib.parse.quote(download_url, safe="/:@?=&"), headers=headers)
+        request = Request(urllib.parse.quote(download_url, safe="/:@?=&"), headers={'Accept': 'application/json', 'User-Agent': 'python3/modgradle server installer' })
         response = urlopen(request)
         print('Downloading mod %s...' % file_name)
         with open('mods' + os.path.sep + file_name, mode='wb') as target:
             target.write(response.read())
+
+
+def get_file_name(project_id, file_id):
+    file_info = Request(f'https://curse.melanx.de/project/{project_id}/file/{file_id}', headers={'Accept': 'application/json', 'User-Agent': 'python3/modgradle server installer'})
+    data = json.loads(urlopen(file_info).read().decode('utf-8'))
+    return data["name"]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is based on #2. It re-adds PackDev without the MultiMC extensions. 
- The install scripts uses CurseMaven now
- The Wrapper API is in a utility class now
- The CurseMaven url is in the same utility class -> only need to change the url in one place

Closes #1 