### PR TITLE
ClasspathExec task

### DIFF
--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/api/task/ClasspathExec.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/api/task/ClasspathExec.java
@@ -1,0 +1,79 @@
+package io.github.noeppi_noeppi.tools.modgradle.api.task;
+
+import net.minecraftforge.gradle.common.tasks.JarExec;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ExternalModuleDependency;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaLauncher;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.work.InputChanges;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A task that executes some java code. Unlike {@link JarExec} this does not require a fatjar.
+ * It will instead resolve a configuration to include dependencies.
+ */
+public abstract class ClasspathExec extends DefaultTask {
+    
+    public ClasspathExec() {
+        this.getJavaLauncher().convention(this.getProject().provider(() -> this.getJavaToolchainService().launcherFor(spec -> spec.getLanguageVersion().set(this.getJavaVersion().map(JavaLanguageVersion::of))).get()));
+        this.getLogFile().set(this.getProject().file("build").toPath().resolve(this.getName()).resolve("log.txt").toFile());
+    }
+
+    /**
+     * The {@link Dependency} to load.
+     */
+    @Input
+    public abstract ListProperty<String> getArgs();
+    
+    public void tool(Object dep) {
+        this.getTool().set(this.getProject().getDependencies().create(dep));
+    }
+    
+    /**
+     * The {@link Dependency} to load.
+     */
+    @Input
+    public abstract Property<Dependency> getTool();
+    
+    /**
+     * The file to write the log.
+     */
+    @OutputFile
+    public abstract RegularFileProperty getLogFile();
+
+    @Inject
+    protected abstract JavaToolchainService getJavaToolchainService();
+    
+    /**
+     * The java version to use.
+     */
+    @Input
+    public abstract Property<Integer> getJavaVersion();
+    
+    /**
+     * The java launcher to use.
+     */
+    @Input
+    public abstract Property<JavaLauncher> getJavaLauncher();
+
+    protected List<String> processArgs(List<String> args) {
+        return args;
+    }
+    
+    @TaskAction
+    public void exec(InputChanges changes) throws IOException {
+        // TODO
+    }
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/ArgumentUtil.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/ArgumentUtil.java
@@ -1,0 +1,50 @@
+package io.github.noeppi_noeppi.tools.modgradle.util;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ArgumentUtil {
+
+    protected final List<String> replaceArgs(List<String> args, Map<String, List<?>> replacements) {
+        if (replacements.isEmpty()) return args;
+        ArrayList<String> newArgs = new ArrayList<>();
+        for (String arg : args) {
+            if (arg.startsWith("{") && arg.endsWith("}")) {
+                String id = arg.substring(1, arg.length() - 1);
+                if (replacements.containsKey(id)) {
+                    List<?> values = replacements.get(id);
+                    if (values.isEmpty()) {
+                        if (newArgs.isEmpty()) throw new IllegalArgumentException("None-Argument substitution on empty list with key " + id);
+                        newArgs.remove(newArgs.size() - 1);
+                    } else if (values.size() == 1) {
+                        newArgs.add(toArgString(values.get(0)));
+                    } else {
+                        if (newArgs.isEmpty()) throw new IllegalArgumentException("Multi-Argument substitution on empty list with key " + id);
+                        String rep = newArgs.get(newArgs.size() - 1);
+                        newArgs.remove(newArgs.size() - 1);
+                        for (Object value : values) {
+                            newArgs.add(rep);
+                            newArgs.add(toArgString(value));
+                        }
+                    }
+                }
+            }
+        }
+        return newArgs;
+    }
+
+    public static String toArgString(Object value) {
+        if (value instanceof String str) {
+            return str;
+        }  else if (value instanceof File file) {
+            return file.toPath().toAbsolutePath().normalize().toString();
+        } else if (value instanceof Path  path) {
+            return path.toAbsolutePath().normalize().toString();
+        } else {
+            return value.toString();
+        }
+    }
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/ConfigurationDownloader.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/ConfigurationDownloader.java
@@ -28,7 +28,7 @@ public class ConfigurationDownloader {
         Set<File> mainFileSet = mainFiles.getFiles();
         if (mainFileSet.isEmpty()) throw new IllegalStateException("Dependency resolved to nothing: " + MgUtil.dependencyName(dependency)); 
         if (mainFileSet.size() > 1) throw new IllegalStateException("Dependency resolved to more than one element: " + MgUtil.dependencyName(dependency)); 
-        String mainClass = JarUtil.mainClass(mainFiles.iterator().next());
+        String mainClass = JarUtil.mainClass(mainFileSet.iterator().next());
         if (mainClass == null) throw new IllegalStateException("No main class found in dependency: " + MgUtil.dependencyName(dependency));
         return new Executable(mainClass, files);
     }

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/ConfigurationDownloader.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/ConfigurationDownloader.java
@@ -1,0 +1,92 @@
+package io.github.noeppi_noeppi.tools.modgradle.util;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ExternalModuleDependency;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.FileCollection;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ConfigurationDownloader {
+
+    private static final AtomicInteger CONFIGURATION_ID = new AtomicInteger(0);
+
+    public static Executable executable(Project project, Dependency dependency) throws IOException {
+        FileCollection files = download(project, dependency);
+        if (files == null) return null;
+        // Need to find out main class:
+        // We download the main file again without any dependencies
+        FileCollection mainFiles = download(project, dependency, configuration -> configuration.setTransitive(false));
+        if (mainFiles == null) return null;
+        Set<File> mainFileSet = mainFiles.getFiles();
+        if (mainFileSet.isEmpty()) throw new IllegalStateException("Dependency resolved to nothing: " + depName(dependency)); 
+        if (mainFileSet.size() > 1) throw new IllegalStateException("Dependency resolved to more than one element: " + depName(dependency)); 
+        String mainClass = JarUtil.mainClass(mainFiles.iterator().next());
+        if (mainClass == null) throw new IllegalStateException("No main class found in dependency: " + depName(dependency));
+        return new Executable(mainClass, files);
+    }
+
+    @Nullable
+    public static FileCollection download(Project project, Dependency dependency) {
+        return download(project, dependency, configuration -> {});
+    }
+    
+    @Nullable
+    public static FileCollection download(Project project, Dependency dependency, Action<Configuration> action) {
+        Configuration configuration = project.getConfigurations().create("modgradle_cfg_" + CONFIGURATION_ID.getAndIncrement());
+        configuration.getDependencies().add(dependency);
+        configuration.resolutionStrategy(resolution -> {
+            resolution.cacheChangingModulesFor(10, TimeUnit.MINUTES);
+            resolution.cacheDynamicVersionsFor(10, TimeUnit.MINUTES);
+        });
+        action.execute(configuration);
+        FileCollection files = download(project, configuration, depName(dependency));
+        project.getConfigurations().remove(configuration);
+        return files;
+    }
+
+    @Nullable
+    public static FileCollection download(Project project, Configuration configuration) {
+        return download(project, configuration, false);
+    }
+    
+    @Nullable
+    public static FileCollection download(Project project, Configuration configuration, boolean removeConfiguration) {
+        FileCollection files = download(project, configuration);
+        if (removeConfiguration) project.getConfigurations().remove(configuration);
+        return files;
+    }
+    
+    @Nullable
+    private static FileCollection download(Project project, Configuration configuration, String name) {
+        Set<File> files;
+        try {
+            files = configuration.resolve();
+        } catch (NullPointerException e) {
+            // According to forge, this might sometimes happen.
+            new IllegalStateException("Failed to resolve configuration for " + name, e).printStackTrace();
+            return null;
+        }
+        ConfigurableFileCollection fc = project.files();
+        files.forEach(fc::from);
+        return fc;
+    }
+    
+    private static String depName(Dependency dependency) {
+        if (dependency instanceof ExternalModuleDependency emd) {
+            return emd.getGroup() + ":" + emd.getName() + ":" + emd.getVersion();
+        } else {
+            return dependency.toString();
+        }
+    }
+    
+    public record Executable(String mainClass, FileCollection classpath) {}
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/JarUtil.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/JarUtil.java
@@ -1,0 +1,46 @@
+package io.github.noeppi_noeppi.tools.modgradle.util;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.module.ModuleDescriptor;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.Manifest;
+
+public class JarUtil {
+    
+    @Nullable
+    public static String mainClass(File jarFile) throws IOException {
+        return mainClass(jarFile.toPath());
+    }
+    
+    @Nullable
+    public static String mainClass(Path jarFile) throws IOException {
+        FileSystem fs = IOUtil.getFileSystem(jarFile.toAbsolutePath().normalize().toUri());
+        
+        Path manifestPath = fs.getPath("/META-INF/MANIFEST.MF");
+        if (Files.isRegularFile(manifestPath)) {
+            try (InputStream in = Files.newInputStream(manifestPath)) {
+                Manifest manifest = new Manifest(in);
+                if (manifest.getMainAttributes().containsKey("Main-Class")) {
+                    return manifest.getMainAttributes().get("Main-Class").toString().strip();
+                }
+            }
+        }
+        
+        Path modulePath = fs.getPath("/module-info.class");
+        if (Files.isRegularFile(modulePath)) {
+            try (InputStream in = Files.newInputStream(modulePath)) {
+                ModuleDescriptor module = ModuleDescriptor.read(in);
+                if (module.mainClass().isPresent()) {
+                    return module.mainClass().get();
+                }
+            }
+        }
+        
+        return null;
+    }
+}

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/JarUtil.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/JarUtil.java
@@ -19,28 +19,29 @@ public class JarUtil {
     
     @Nullable
     public static String mainClass(Path jarFile) throws IOException {
-        FileSystem fs = IOUtil.getFileSystem(jarFile.toAbsolutePath().normalize().toUri());
-        
-        Path manifestPath = fs.getPath("/META-INF/MANIFEST.MF");
-        if (Files.isRegularFile(manifestPath)) {
-            try (InputStream in = Files.newInputStream(manifestPath)) {
-                Manifest manifest = new Manifest(in);
-                if (manifest.getMainAttributes().containsKey("Main-Class")) {
-                    return manifest.getMainAttributes().get("Main-Class").toString().strip();
+        try (FileSystem fs = IOUtil.getFileSystem(jarFile.toAbsolutePath().normalize().toUri())) {
+
+            Path manifestPath = fs.getPath("/META-INF/MANIFEST.MF");
+            if (Files.isRegularFile(manifestPath)) {
+                try (InputStream in = Files.newInputStream(manifestPath)) {
+                    Manifest manifest = new Manifest(in);
+                    if (manifest.getMainAttributes().containsKey("Main-Class")) {
+                        return manifest.getMainAttributes().get("Main-Class").toString().strip();
+                    }
                 }
             }
-        }
-        
-        Path modulePath = fs.getPath("/module-info.class");
-        if (Files.isRegularFile(modulePath)) {
-            try (InputStream in = Files.newInputStream(modulePath)) {
-                ModuleDescriptor module = ModuleDescriptor.read(in);
-                if (module.mainClass().isPresent()) {
-                    return module.mainClass().get();
+
+            Path modulePath = fs.getPath("/module-info.class");
+            if (Files.isRegularFile(modulePath)) {
+                try (InputStream in = Files.newInputStream(modulePath)) {
+                    ModuleDescriptor module = ModuleDescriptor.read(in);
+                    if (module.mainClass().isPresent()) {
+                        return module.mainClass().get();
+                    }
                 }
             }
+
+            return null;
         }
-        
-        return null;
     }
 }

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/JarUtil.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/JarUtil.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.module.ModuleDescriptor;
+import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -19,14 +20,15 @@ public class JarUtil {
     
     @Nullable
     public static String mainClass(Path jarFile) throws IOException {
-        try (FileSystem fs = IOUtil.getFileSystem(jarFile.toAbsolutePath().normalize().toUri())) {
-
+        try (FileSystem fs = IOUtil.getFileSystem(URI.create("jar:" + jarFile.toAbsolutePath().normalize().toUri()))) {
             Path manifestPath = fs.getPath("/META-INF/MANIFEST.MF");
             if (Files.isRegularFile(manifestPath)) {
                 try (InputStream in = Files.newInputStream(manifestPath)) {
                     Manifest manifest = new Manifest(in);
-                    if (manifest.getMainAttributes().containsKey("Main-Class")) {
-                        return manifest.getMainAttributes().get("Main-Class").toString().strip();
+                    // containsKey does not work
+                    Object value = manifest.getMainAttributes().getValue("Main-Class");
+                    if (value != null) {
+                        return value.toString().strip();
                     }
                 }
             }

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/MgUtil.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/MgUtil.java
@@ -4,6 +4,8 @@ import net.minecraftforge.gradle.common.util.Artifact;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.provider.Provider;
 
 import javax.annotation.Nullable;
@@ -31,6 +33,14 @@ public class MgUtil {
             }
         } catch (UnknownTaskException | ClassCastException e) {
             return null;
+        }
+    }
+
+    public static String dependencyName(Dependency dependency) {
+        if (dependency instanceof ExternalModuleDependency emd) {
+            return emd.getGroup() + ":" + emd.getName() + ":" + emd.getVersion();
+        } else {
+            return dependency.toString();
         }
     }
     


### PR DESCRIPTION
A task similar to [JarExec](https://github.com/MinecraftForge/ForgeGradle/blob/FG_5.0/src/common/java/net/minecraftforge/gradle/common/tasks/JarExec.java) that resolves dependencies of the tool. This should make it possible to no longer depend on fatjars as they use up quite some disk space.

Needs some testing before tough.