### PR TITLE
Fix modrinth pack format

### DIFF
--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/CurseFile.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/CurseFile.java
@@ -12,7 +12,6 @@ import io.github.noeppi_noeppi.tools.modgradle.util.Side;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -28,21 +27,6 @@ public record CurseFile(int projectId, int fileId, Side side) {
 
     public String fileName() throws IOException {
         return CurseUtil.API.getFile(this.projectId, this.fileId).name();
-    }
-
-    public int fileSize() {
-        HttpURLConnection conn = null;
-        try {
-            conn = (HttpURLConnection) this.downloadUrl().toURL().openConnection();
-            conn.setRequestMethod("HEAD");
-            return conn.getContentLength();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        } finally {
-            if (conn != null) {
-                conn.disconnect();
-            }
-        }
     }
 
     public static CurseFile parse(JsonObject json) {

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/CurseFile.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/CurseFile.java
@@ -12,6 +12,7 @@ import io.github.noeppi_noeppi.tools.modgradle.util.Side;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -27,6 +28,21 @@ public record CurseFile(int projectId, int fileId, Side side) {
 
     public String fileName() throws IOException {
         return CurseUtil.API.getFile(this.projectId, this.fileId).name();
+    }
+
+    public int fileSize() {
+        HttpURLConnection conn = null;
+        try {
+            conn = (HttpURLConnection) this.downloadUrl().toURL().openConnection();
+            conn.setRequestMethod("HEAD");
+            return conn.getContentLength();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
     }
 
     public static CurseFile parse(JsonObject json) {

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildModrinthPackTask.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildModrinthPackTask.java
@@ -57,7 +57,7 @@ public class BuildModrinthPackTask extends BuildTargetTask {
             futures.add(service.submit(() -> {
                 try {
                     InputStream in = file.downloadUrl().toURL().openStream();
-                    FileMeta meta = new FileMeta(IOUtils.toByteArray(in).length, IOUtil.commonHashes(in));
+                    FileMeta meta = new FileMeta(in.readAllBytes().length, IOUtil.commonHashes(in));
                     metaMap.put(file, meta);
                     in.close();
                 } catch (IOException e) {

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildModrinthPackTask.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildModrinthPackTask.java
@@ -6,6 +6,7 @@ import io.github.noeppi_noeppi.tools.modgradle.ModGradle;
 import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.CurseFile;
 import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.PackSettings;
 import io.github.noeppi_noeppi.tools.modgradle.util.IOUtil;
+import io.github.noeppi_noeppi.tools.modgradle.util.Side;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.file.PathUtils;
 import org.gradle.api.internal.provider.DefaultProvider;
@@ -35,9 +36,13 @@ public class BuildModrinthPackTask extends BuildTargetTask {
         FileSystem fs = FileSystems.newFileSystem(URI.create("jar:" + target.toUri()), Map.of(
                 "create", String.valueOf(!Files.exists(target))
         ));
-        Files.createDirectories(fs.getPath("overrides"));
-        for (Path src : this.getOverridePaths(null)) {
-            PathUtils.copyDirectory(src, fs.getPath("overrides"));
+        Files.createDirectories(fs.getPath("client-overrides"));
+        for (Path src : this.getOverridePaths(Side.CLIENT)) {
+            PathUtils.copyDirectory(src, fs.getPath("client-overrides"));
+        }
+        Files.createDirectories(fs.getPath("server-overrides"));
+        for (Path src : this.getOverridePaths(Side.SERVER)) {
+            PathUtils.copyDirectory(src, fs.getPath("server-overrides"));
         }
         this.generateIndex(fs.getPath("modrinth.index.json"));
         fs.close();

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildModrinthPackTask.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/plugins/packdev/task/BuildModrinthPackTask.java
@@ -7,6 +7,7 @@ import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.CurseFile;
 import io.github.noeppi_noeppi.tools.modgradle.plugins.packdev.PackSettings;
 import io.github.noeppi_noeppi.tools.modgradle.util.IOUtil;
 import org.apache.commons.io.file.PathUtils;
+import org.gradle.api.internal.provider.DefaultProvider;
 
 import javax.inject.Inject;
 import java.io.IOException;
@@ -24,6 +25,7 @@ public class BuildModrinthPackTask extends BuildTargetTask {
     @Inject
     public BuildModrinthPackTask(PackSettings settings, List<CurseFile> files, String edition) {
         super(settings, files, edition);
+        this.getArchiveExtension().convention(new DefaultProvider<>(() -> "mrpack"));
     }
 
     @Override
@@ -35,7 +37,7 @@ public class BuildModrinthPackTask extends BuildTargetTask {
         for (Path src : this.getOverridePaths(null)) {
             PathUtils.copyDirectory(src, fs.getPath("overrides"));
         }
-        this.generateIndex(fs.getPath("index.json"));
+        this.generateIndex(fs.getPath("modrinth.index.json"));
         fs.close();
     }
 
@@ -99,6 +101,7 @@ public class BuildModrinthPackTask extends BuildTargetTask {
                 }
             }
             fileObj.add("hashes", hashesObj);
+            fileObj.addProperty("fileSize", file.fileSize());
 
             fileArray.add(fileObj);
         }

--- a/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/IOUtil.java
+++ b/plugin/src/main/java/io/github/noeppi_noeppi/tools/modgradle/util/IOUtil.java
@@ -53,21 +53,25 @@ public class IOUtil {
     public static Map<String, String> commonHashes(@WillClose InputStream in) throws IOException {
         MessageDigest sha1;
         MessageDigest sha256;
+        MessageDigest sha512;
         MessageDigest md5;
         try {
             sha1 = MessageDigest.getInstance("SHA1");
             sha256 = MessageDigest.getInstance("SHA256");
+            sha512 = MessageDigest.getInstance("SHA512");
             md5 = MessageDigest.getInstance("MD5");
             try (
                     InputStream in1 = new DigestInputStream(in, sha1);
                     InputStream in2 = new DigestInputStream(in1, sha256);
-                    InputStream in3 = new DigestInputStream(in2, md5)
+                    InputStream in3 = new DigestInputStream(in2, sha512);
+                    InputStream in4 = new DigestInputStream(in3, md5)
             ) {
-                in3.readAllBytes();
+                in4.readAllBytes();
             }
             ImmutableMap.Builder<String, String> map = ImmutableMap.builder();
             map.put("sha1", String.format("%040X", new BigInteger(1, sha1.digest())));
             map.put("sha256", String.format("%064X", new BigInteger(1, sha256.digest())));
+            map.put("sha512", String.format("%128X", new BigInteger(1, sha512.digest())));
             map.put("md5", String.format("%032X", new BigInteger(1, md5.digest())));
             return map.build();
         } catch (NoSuchAlgorithmException e) {


### PR DESCRIPTION
Modrinth made changes to the pack format or it was never correct on our end.
This PR does the following:
- change extension to `mrpack`
- rename `index.json` to `modrinth.index.json`
- add `fileSize` for each mod in `modrinth.index.json`
- add `sha512` hash for each mod