### PR TITLE
Add support for version suffix

### DIFF
--- a/src/main/java/org/moddingx/modgradle/plugins/meta/delegate/ModVersionConfig.java
+++ b/src/main/java/org/moddingx/modgradle/plugins/meta/delegate/ModVersionConfig.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 public class ModVersionConfig {
 
     @Nullable public String base;
+    @Nullable public String suffix;
     public Strategy strategy = Strategy.Constant.INSTANCE;
 
     public Delegate delegate() {
@@ -30,6 +31,10 @@ public class ModVersionConfig {
 
         public void base(String version) {
             ModVersionConfig.this.base = Objects.requireNonNull(version);
+        }
+
+        public void suffix(String suffix) {
+            ModVersionConfig.this.suffix = Objects.requireNonNull(suffix);
         }
         
         public void maven(String repository) throws URISyntaxException {

--- a/src/main/java/org/moddingx/modgradle/plugins/meta/setup/ModContext.java
+++ b/src/main/java/org/moddingx/modgradle/plugins/meta/setup/ModContext.java
@@ -63,12 +63,14 @@ public final class ModContext extends ProjectContext {
     }
 
     private static String resolveVersion(Project project, String group, ModVersionConfig delegate) throws IOException {
-        return switch (delegate.strategy) {
+        String resolvedVersion = switch (delegate.strategy) {
             case ModVersionConfig.Strategy.Constant.INSTANCE -> delegate.base == null ? project.getVersion().toString() : delegate.base;
             case ModVersionConfig.Strategy.Maven maven when delegate.base == null -> throw new IllegalStateException("Needs a base version to get version from a maven repository.");
             case ModVersionConfig.Strategy.Maven maven -> MavenVersionResolver.getVersion(project, maven.repository(), group, project.getName(), delegate.base);
             case ModVersionConfig.Strategy.GitTag.INSTANCE -> GitTagVersionResolver.getVersion(project, delegate.base);
         };
+        if (delegate.suffix != null) resolvedVersion += "-" + delegate.suffix;
+        return resolvedVersion;
     }
 
     private static LazyValue<String> getChangelogProvider(Project project, @Nullable String commitFormat, @Nullable Closure<String> customChangelog) throws IOException {

--- a/src/main/java/org/moddingx/modgradle/plugins/meta/setup/ModContext.java
+++ b/src/main/java/org/moddingx/modgradle/plugins/meta/setup/ModContext.java
@@ -69,7 +69,7 @@ public final class ModContext extends ProjectContext {
             case ModVersionConfig.Strategy.Maven maven -> MavenVersionResolver.getVersion(project, maven.repository(), group, project.getName(), delegate.base);
             case ModVersionConfig.Strategy.GitTag.INSTANCE -> GitTagVersionResolver.getVersion(project, delegate.base);
         };
-        if (delegate.suffix != null) resolvedVersion += "-" + delegate.suffix;
+        if (delegate.suffix != null && !delegate.suffix.isBlank()) resolvedVersion += "-" + delegate.suffix;
         return resolvedVersion;
     }
 


### PR DESCRIPTION
This way, someone can simply add `suffix` to the version if wanted. 

Could be used like that:

```groovy
versioning {
    base '1.0'
    maven 'https://maven.moddingx.org/release'
    suffix 'test'
}
```

This could set the version to `1.0.0-test`.