### PR TITLE
[v4] Fix Srg2Source tasks failing to run

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     api('org.apache.maven:maven-artifact') { version { strictly '[3.9.2,)'; prefer '3.9.2' } }
     api('org.apache.maven:maven-repository-metadata') { version { strictly '[3.9.2,)'; prefer '3.9.2' } }
     api('net.minecraftforge:srgutils') { version { strictly '[0.5.1,)'; prefer '0.5.1' } }
-    api('net.minecraftforge.gradle:ForgeGradle') { version { strictly "[6.0.6,6.2)"; prefer '6.0.6' } }
+    api('net.minecraftforge.gradle:ForgeGradle') { version { strictly "[6.0.6,6.2)"; prefer '6.0.27' } }
     api('net.minecraftforge:artifactural') { version { strictly '[3.0.14,)'; prefer '3.0.14' } }
     compileOnly('org.parchmentmc:librarian') { version { strictly '[1.2.0,)'; prefer '1.2.0' } }
     api('de.siegmar:fastcsv') { version { strictly '[2.2.2,)'; prefer '2.2.2' } }

--- a/plugin/src/main/java/org/moddingx/modgradle/plugins/sourcejar/SourceJarPlugin.java
+++ b/plugin/src/main/java/org/moddingx/modgradle/plugins/sourcejar/SourceJarPlugin.java
@@ -114,13 +114,11 @@ public class SourceJarPlugin implements Plugin<Project> {
             createRangeMap.getDependencies().from(classpath);
             createRangeMap.getOutput().set(project.file("build").toPath().resolve(createRangeMap.getName()).resolve("rangemap.txt").toFile());
             createRangeMap.getSourceCompatibility().set(java.map(jv -> jv <= 8 ? "JAVA_1_" + jv : "JAVA_" + jv));
-            createRangeMap.setRuntimeJavaToolchain(JavaEnv.getJavaExtension(project).get().getToolchain());
 
             applyRangeMap.getSources().from(sources);
             applyRangeMap.getSrgFiles().from(mergeSourceMappings.getOutput());
             applyRangeMap.getRangeMap().set(createRangeMap.getOutput());
             applyRangeMap.getOutput().set(project.file("build").toPath().resolve(applyRangeMap.getName()).resolve("srg_sources.zip").toFile());
-            applyRangeMap.setRuntimeJavaToolchain(JavaEnv.getJavaExtension(project).get().getToolchain());
             
             if (jarTask != null) {
                 mergeJars.getBase().set(jarTask.getArchiveFile());


### PR DESCRIPTION
The sourcejar's srg2source tasks are manually setting the runtime toolchain to be that of the project's. This was fine, but srg2source was recently updated with Java 21 features, which means that this won't work. We accounted for this in ForgeGradle 6 and also have the version of srg2source pinned in 6.0.27, but that means manually setting the toolchain will no longer work.

This PR fixes this bug by removing the lines that set the runtime toolchain. I also bumped the preferred version of FG6 to when the dependencies used are set to pinned versions, rather than being unpinned (i.e. `8.+` for srg2source).