### PR TITLE
Limit changelog length to 4096 characters for Modrinth uploads

### DIFF
--- a/src/main/java/org/moddingx/modgradle/plugins/meta/setup/ModUploadSetup.java
+++ b/src/main/java/org/moddingx/modgradle/plugins/meta/setup/ModUploadSetup.java
@@ -64,7 +64,7 @@ public class ModUploadSetup {
         }
         if (config.modrinth.projectId != null) {
             mod.project().getPlugins().apply("com.modrinth.minotaur");
-            String changelog = mod.changelog().substring(0, 4096);
+            String changelog = trimChangelog(mod.changelog(), 4096);
             ModrinthExtension ext = mod.project().getExtensions().getByType(ModrinthExtension.class);
 
             String secret = System.getenv(config.modrinth.secretEnv);
@@ -104,5 +104,19 @@ public class ModUploadSetup {
 
             mod.project().afterEvaluate(p -> uploadTask.configure(task -> task.dependsOn(p.getTasks().named("modrinth"))));
         }
+    }
+
+    private static String trimChangelog(String changelog, int maxLength) {
+        if (changelog.length() <= maxLength) {
+            return changelog;
+        }
+
+        int lastNewlineIndex = changelog.lastIndexOf('\n', maxLength);
+
+        if (lastNewlineIndex != -1) {
+            return changelog.substring(0, lastNewlineIndex);
+        }
+
+        return changelog.substring(0, maxLength);
     }
 }

--- a/src/main/java/org/moddingx/modgradle/plugins/meta/setup/ModUploadSetup.java
+++ b/src/main/java/org/moddingx/modgradle/plugins/meta/setup/ModUploadSetup.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Locale;
 
 public class ModUploadSetup {
+    
+    private static final int MODRINTH_CHANGELOG_MAX_LENGTH = 4096;
 
     public static void configureBuild(ModContext mod, ModArtifactSetup.ConfiguredArtifacts artifacts, ModUploadsConfig config) {
         TaskProvider<Task> uploadTask = mod.project().getTasks().register("upload", task -> task.setGroup("publishing"));
@@ -64,7 +66,7 @@ public class ModUploadSetup {
         }
         if (config.modrinth.projectId != null) {
             mod.project().getPlugins().apply("com.modrinth.minotaur");
-            String changelog = trimChangelog(mod.changelog(), 4096);
+            String changelog = cutChangelogForModrinthUpload(mod.changelog());
             ModrinthExtension ext = mod.project().getExtensions().getByType(ModrinthExtension.class);
 
             String secret = System.getenv(config.modrinth.secretEnv);
@@ -106,17 +108,10 @@ public class ModUploadSetup {
         }
     }
 
-    private static String trimChangelog(String changelog, int maxLength) {
-        if (changelog.length() <= maxLength) {
-            return changelog;
-        }
-
-        int lastNewlineIndex = changelog.lastIndexOf('\n', maxLength);
-
-        if (lastNewlineIndex != -1) {
-            return changelog.substring(0, lastNewlineIndex);
-        }
-
-        return changelog.substring(0, maxLength);
+    private static String cutChangelogForModrinthUpload(String changelog) {
+        if (changelog.length() <= MODRINTH_CHANGELOG_MAX_LENGTH) return changelog;
+        int lastNewlineIndex = changelog.lastIndexOf('\n', MODRINTH_CHANGELOG_MAX_LENGTH);
+        if (lastNewlineIndex != -1) return changelog.substring(0, lastNewlineIndex);
+        return changelog.substring(0, MODRINTH_CHANGELOG_MAX_LENGTH);
     }
 }

--- a/src/main/java/org/moddingx/modgradle/plugins/meta/setup/ModUploadSetup.java
+++ b/src/main/java/org/moddingx/modgradle/plugins/meta/setup/ModUploadSetup.java
@@ -64,7 +64,7 @@ public class ModUploadSetup {
         }
         if (config.modrinth.projectId != null) {
             mod.project().getPlugins().apply("com.modrinth.minotaur");
-            String changelog = mod.changelog();
+            String changelog = mod.changelog().substring(0, 4096);
             ModrinthExtension ext = mod.project().getExtensions().getByType(ModrinthExtension.class);
 
             String secret = System.getenv(config.modrinth.secretEnv);


### PR DESCRIPTION
If the changelog is too long, you get an error like this:

* What went wrong:
Execution failed for task ':modrinth'.
> Failed to upload file to Modrinth! EndpointException(error=invalid_input, description=Error while validating input: Field version_body failed validation with error: length)


The length is taken from https://github.com/modrinth/code/blob/701fef08f831d0c634151f67eeba96f9eb5342bf/apps/labrinth/src/routes/v3/version_creation.rs#L66