### PR TITLE
Add a way to detect the newly introduced (1.21.9) pack version format

### DIFF
--- a/src/main/java/org/moddingx/modgradle/util/ModGradleVersionAccess.java
+++ b/src/main/java/org/moddingx/modgradle/util/ModGradleVersionAccess.java
@@ -100,8 +100,12 @@ public class ModGradleVersionAccess {
                     if (path.equals("version.json")) {
                         Reader reader = new InputStreamReader(zin, StandardCharsets.UTF_8);
                         JsonObject json = GSON.fromJson(reader, JsonObject.class);
-                        if (json.has("pack_version") && json.get("pack_version").isJsonObject() && json.get("pack_version") instanceof JsonObject packVersionObj && packVersionObj.has("resource")) {
-                            packVersions = new PackVersions(packVersionObj.get("resource").getAsInt(), packVersionObj.has("data") ? Optional.of(packVersionObj.get("data").getAsInt()) : Optional.empty());
+                        if (json.has("pack_version") && json.get("pack_version").isJsonObject() && json.get("pack_version") instanceof JsonObject packVersionObj) {
+                            if (packVersionObj.has("resource")) {
+                                packVersions = new PackVersions(packVersionObj.get("resource").getAsInt(), packVersionObj.has("data") ? Optional.of(packVersionObj.get("data").getAsInt()) : Optional.empty());
+                            } else if (packVersionObj.has("resource_major")) {
+                                packVersions = new PackVersions(packVersionObj.get("resource_major").getAsInt(), packVersionObj.has("data_major") ? Optional.of(packVersionObj.get("data_major").getAsInt()) : Optional.empty());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Here you can see that the 1.21.9 version changed it's pack version format:

<img width="887" height="365" alt="image" src="https://github.com/user-attachments/assets/b91c78fa-15d1-4076-a64b-a7336dfbc60c" />

Without this PR, this issue occurs:
```
Caused by: java.lang.RuntimeException: Could not get pack versions for 1.21.9
	at org.moddingx.modgradle.util.ModGradleVersionAccess.packVersions(ModGradleVersionAccess.java:116)
	at org.moddingx.modgradle.util.ModGradleVersionAccess.resource(ModGradleVersionAccess.java:82)
	at org.moddingx.modgradle.plugins.meta.setup.ModContext.<init>(ModContext.java:46)
	at org.moddingx.modgradle.plugins.meta.setup.ModBuildSetup.configureBuild(ModBuildSetup.java:19)
	at org.moddingx.modgradle.plugins.meta.ModExtension.configure(ModExtension.java:37)
	... 195 more
Caused by: java.io.IOException: No valid version.json file found in client.
	at org.moddingx.modgradle.util.ModGradleVersionAccess.packVersions(ModGradleVersionAccess.java:110)
	... 199 more
```

This PR fixes that.