### PR TITLE
Add configurable main jar task and jarJar integration

### DIFF
--- a/src/main/java/org/moddingx/modgradle/plugins/meta/delegate/ModArtifactsConfig.java
+++ b/src/main/java/org/moddingx/modgradle/plugins/meta/delegate/ModArtifactsConfig.java
@@ -8,7 +8,10 @@ public class ModArtifactsConfig {
     
     @Nullable public ArtifactConfig sources = null;
     @Nullable public ArtifactConfig javadoc = null;
-    
+    public String mainJarTaskName = "jar";
+    public String jarClassifier = "";
+    public String jarJarClassifier = "all";
+
     public Delegate delegate() {
         return new Delegate();
     }
@@ -39,6 +42,18 @@ public class ModArtifactsConfig {
                 ModArtifactsConfig.this.javadoc = new ArtifactConfig();
             }
             ModConfig.configure(closure, ModArtifactsConfig.this.javadoc.delegate());
+        }
+
+        public void useJarJar() {
+            this.useJarJar(false);
+        }
+
+        public void useJarJar(boolean switchClassifier) {
+            ModArtifactsConfig.this.mainJarTaskName = "jarJar";
+            if (switchClassifier) {
+                ModArtifactsConfig.this.jarClassifier = "thin";
+                ModArtifactsConfig.this.jarJarClassifier = "";
+            }
         }
     }
     

--- a/src/main/java/org/moddingx/modgradle/plugins/meta/setup/ModArtifactSetup.java
+++ b/src/main/java/org/moddingx/modgradle/plugins/meta/setup/ModArtifactSetup.java
@@ -16,8 +16,18 @@ public class ModArtifactSetup {
     public static ConfiguredArtifacts configureBuild(ModContext mod, ModArtifactsConfig config) {
         BuildableArtifact sourceArtifact = null;
         BuildableArtifact javadocArtifact = null;
-        TaskProvider<Jar> jar = mod.project().getTasks().named("jar", Jar.class);
+        mod.project().getTasks().withType(Jar.class).configureEach(task -> {
+            String taskName = task.getName();
+            if (taskName.equals("jar")) {
+                task.getArchiveClassifier().convention(config.jarClassifier);
+            } else if (taskName.equals("jarJar")) {
+                task.getArchiveClassifier().convention(config.jarJarClassifier);
+            }
+        });
+        String mainJarTaskName = config.mainJarTaskName;
+        TaskProvider<Jar> jar = mod.project().getTasks().named(mainJarTaskName, Jar.class);
         TaskProvider<Task> build = mod.project().getTasks().named("build");
+        build.configure(task -> task.dependsOn(jar));
         if (config.sources != null) {
             TaskProvider<Jar> sourceJarTask = mod.project().getTasks().register("sourcesJar", Jar.class, task -> {
                 task.setGroup("build");


### PR DESCRIPTION
This PR adds support for using JarJar in ModGradle easily, especially for publishing the artifacts.

You can use it like this:

```groovy
mod.configure {
    artifacts {
        useJarJar()
    }
}
```

That way, the main jar task for publishing isn't the default `jar` task anymore but instead `jarJar`. If using `useJarJar(tue)`, it also switches the classifier of the default task to `thin` and the jarJar task classifier to an empty string. 